### PR TITLE
Add support for posting the category with an html post

### DIFF
--- a/Snippets/Snippets+Micropub.swift
+++ b/Snippets/Snippets+Micropub.swift
@@ -93,7 +93,7 @@ extension Snippets {
             })
         }
         
-        static public func postHtml(_ identity : Snippets.Configuration, title : String, content : String, isDraft : Bool = false, location : SnippetsLocation? = nil, completion: @escaping(Error?, String?) -> ()) -> UUHttpRequest?
+		static public func postHtml(_ identity : Snippets.Configuration, title : String, content : String, category : String? = nil, isDraft : Bool = false, location : SnippetsLocation? = nil, completion: @escaping(Error?, String?) -> ()) -> UUHttpRequest?
         {
             // Pre-flight check to see if we are even configured...
             if identity.micropubToken.count == 0 {
@@ -113,6 +113,10 @@ extension Snippets {
                 properties["post-status"] = [ "published" ]
             }
 
+			if let category = category {
+				properties["category"] = [ category ]
+			}
+			
 			if let location = location {
 				if location.name.count > 0 {
 					properties["checkin"] = [

--- a/Snippets/Snippets.swift
+++ b/Snippets/Snippets.swift
@@ -75,9 +75,9 @@ public class Snippets : NSObject {
         }
     }
     
-    @objc public func postHtml(title : String, content : String, isDraft : Bool = false, completion: @escaping(Error?, String?) -> ()) -> UUHttpRequest? {
+	@objc public func postHtml(title : String, content : String, category : String? = nil, isDraft : Bool = false, completion: @escaping(Error?, String?) -> ()) -> UUHttpRequest? {
         if Snippets.Configuration.publishing.type == .micropub {
-            return Snippets.Micropub.postHtml(Snippets.Configuration.publishing, title: title, content: content, completion: completion)
+			return Snippets.Micropub.postHtml(Snippets.Configuration.publishing, title: title, content: content, category: category, completion: completion)
         }
         else {
             let request = Snippets.XMLRPC.Request.publishPostRequest(identity: Snippets.Configuration.publishing, existingPost: false)


### PR DESCRIPTION
I had a user request to add Categories as an optional parameter when posting using Humboldt. I had to update Snippets to send the Category wiith the Micropub request. These are the changes I had to make.